### PR TITLE
[chore] Update actions/cache to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: '15.x'
       - run: npm install
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: node_modules-${{ github.sha }}
           path: |
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: '15.x'
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: node_modules-${{ github.sha }}
           path: |
@@ -51,7 +51,7 @@ jobs:
         with:
           node-version: '15.x'
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: node_modules-${{ github.sha }}
           path: |
@@ -69,7 +69,7 @@ jobs:
         with:
           node-version: '15.x'
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: node_modules-${{ github.sha }}
           path: |
@@ -90,7 +90,7 @@ jobs:
           node-version: '15.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: node_modules-${{ github.sha }}
           path: |


### PR DESCRIPTION
v2 is out of date and workflows will fail from Feb 2025. v4 is the latest version