### PR TITLE
Enable Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: daily
+    rebase-strategy: auto
+    # Disable Dependabot version updates
+    # We are only interested in security updates
+    open-pull-requests-limit: 0
+    groups:
+      major:
+        update-types:
+          - 'major'
+        applies-to: security-updates
+      minor:
+        update-types:
+          - 'minor'
+        applies-to: security-updates
+      patch:
+        update-types:
+          - 'patch'
+        applies-to: security-updates


### PR DESCRIPTION
## Summary
- Enable security-only Dependabot updates for npm dependencies
- Configure automatic rebasing for all dependency updates
- Group updates by severity level (major/minor/patch)

## Configuration Details
- **Package ecosystem**: npm
- **Update strategy**: Security updates only (`open-pull-requests-limit: 0`)
- **Grouping**: Separate groups for major, minor, and patch security updates
- **Rebasing**: Automatic (`rebase-strategy: auto`)

## Vulnerabilities Found
GitHub reports 5 vulnerabilities (2 high, 3 moderate) that this configuration will help address.

## Test Plan
- [ ] Verify Dependabot configuration is valid
- [ ] Confirm security updates will be created for the reported vulnerabilities
- [ ] Verify updates are grouped correctly by severity
- [ ] Confirm automatic rebasing works as expected